### PR TITLE
[MS-937] - Use posology if present instead of the getter posologyText

### DIFF
--- a/src/main/kotlin/org/taktik/icure/be/ehealth/logic/kmehr/v20161201/KmehrExport.kt
+++ b/src/main/kotlin/org/taktik/icure/be/ehealth/logic/kmehr/v20161201/KmehrExport.kt
@@ -383,8 +383,13 @@ open class KmehrExport {
                     }}
                 }
             }
-            cnt?.medicationValue?.posologyText?.let {
+            cnt?.medicationValue?.posology?.let {
                 item.posology = ItemType.Posology().apply { text = TextType().apply { l = lang; value = it } }
+            }
+            if(item.posology == null) {
+                cnt?.medicationValue?.posologyText?.let {
+                    item.posology = ItemType.Posology().apply { text = TextType().apply { l = lang; value = it } }
+                }
             }
             cnt?.medicationValue?.instructionForPatient?.let {
                 item.instructionforpatient = TextType().apply { l = lang; value = it }


### PR DESCRIPTION
With this change the backend will not use to auto generated posology (https://github.com/taktik/icure-backend/blob/bf29ac1179bd8a5ba8c5056e7bce2db2ef1b9e17/src/main/java/org/taktik/icure/entities/embed/Medication.java#L302-L324) if there is already a posology specified in `posology`.