### PR TITLE
MS-1633 Avoid creating list with null patient sfk

### DIFF
--- a/src/main/java/org/taktik/icure/logic/impl/filter/service/ServiceByHcPartyTagCodeDateFilter.java
+++ b/src/main/java/org/taktik/icure/logic/impl/filter/service/ServiceByHcPartyTagCodeDateFilter.java
@@ -54,9 +54,10 @@ public class ServiceByHcPartyTagCodeDateFilter
 		try {
             String hcPartyId = filter.getHealthcarePartyId() != null ? filter.getHealthcarePartyId() : getLoggedHealthCarePartyId();
             HashSet<String> ids = null;
-            List<String> patientSFKList = filter.getPatientSecretForeignKey() != null ?
-                    Arrays.asList(filter.getPatientSecretForeignKey()) :
-                    null;
+
+            String patientSFK = filter.getPatientSecretForeignKey();
+            List<String> patientSFKList = patientSFK != null ? Arrays.asList(patientSFK) : null;
+
             if (filter.getTagType() != null && filter.getTagCode() != null) {
                 ids = new HashSet<>(contactLogic.findServicesByTag(
                         hcPartyId,

--- a/src/main/java/org/taktik/icure/logic/impl/filter/service/ServiceByHcPartyTagCodeDateFilter.java
+++ b/src/main/java/org/taktik/icure/logic/impl/filter/service/ServiceByHcPartyTagCodeDateFilter.java
@@ -54,10 +54,13 @@ public class ServiceByHcPartyTagCodeDateFilter
 		try {
             String hcPartyId = filter.getHealthcarePartyId() != null ? filter.getHealthcarePartyId() : getLoggedHealthCarePartyId();
             HashSet<String> ids = null;
+            List<String> patientSFKList = filter.getPatientSecretForeignKey() != null ?
+                    Arrays.asList(filter.getPatientSecretForeignKey()) :
+                    null;
             if (filter.getTagType() != null && filter.getTagCode() != null) {
                 ids = new HashSet<>(contactLogic.findServicesByTag(
                         hcPartyId,
-                        Arrays.asList(filter.getPatientSecretForeignKey()), filter.getTagType(),
+                        patientSFKList, filter.getTagType(),
                         filter.getTagCode(), filter.getStartValueDate(), filter.getEndValueDate()
                 ));
             }
@@ -65,7 +68,7 @@ public class ServiceByHcPartyTagCodeDateFilter
             if (filter.getCodeType() != null && filter.getCodeCode() != null) {
                 List<String> byCode = contactLogic.findServicesByCode(
                         hcPartyId,
-                        Arrays.asList(filter.getPatientSecretForeignKey()), filter.getCodeType(),
+                        patientSFKList, filter.getCodeType(),
                         filter.getCodeCode(), filter.getStartValueDate(), filter.getEndValueDate()
                 );
                 if (ids==null) { ids = new HashSet<>(byCode); } else { ids.retainAll(byCode); }


### PR DESCRIPTION
ServiceByHcPartyTagCodeDateFilter.getPatientSecretForeignKey() can return null. Avoid creating a list that contains [null] before applying Arrays.asList.