### PR TITLE
Use HTTPS for the Spring Maven repo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
 	repositories {
 		mavenCentral()
 		maven { url = 'https://maven.taktik.be/content/groups/public' }
-		maven { url = 'http://repo.spring.io/plugins-release' }
+		maven { url = 'https://repo.spring.io/plugins-release' }
 	}
 	dependencies {
 		classpath('io.spring.gradle:propdeps-plugin:0.0.9.RELEASE')

--- a/misc/bin/build.gradle
+++ b/misc/bin/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     repositories {
         mavenCentral()
         maven { url = 'https://maven.taktik.be/content/groups/public' }
-        maven { url = 'http://repo.spring.io/plugins-release' }
+        maven { url = 'https://repo.spring.io/plugins-release' }
     }
     dependencies {
         classpath('io.spring.gradle:propdeps-plugin:0.0.9.RELEASE')

--- a/misc/build.gradle
+++ b/misc/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     repositories {
         mavenCentral()
         maven { url = 'https://maven.taktik.be/content/groups/public' }
-        maven { url = 'http://repo.spring.io/plugins-release' }
+        maven { url = 'https://repo.spring.io/plugins-release' }
     }
     dependencies {
         classpath('io.spring.gradle:propdeps-plugin:0.0.9.RELEASE')


### PR DESCRIPTION
On `./gradlew bootRun`, the dependency `http://repo.spring.io/plugins-release/io/spring/gradle/propdeps-plugin/0.0.9.RELEASE/propdeps-plugin-0.0.9.RELEASE.pom` is unreachable ("HTTP is not supported. Please use HTTPS").

This PR changes all `gradle.build` URLs to `repo.spring.io` to use HTTPS.

Let me know if I should make the PR to upstream instead.