### PR TITLE
[MS-3248] Empty hcp parent id check improvement 

### DIFF
--- a/src/main/java/org/taktik/icure/logic/impl/HealthcarePartyLogicImpl.java
+++ b/src/main/java/org/taktik/icure/logic/impl/HealthcarePartyLogicImpl.java
@@ -203,7 +203,7 @@ public class HealthcarePartyLogicImpl extends GenericLogicImpl<HealthcareParty, 
 
         HealthcareParty hcpInHierarchy = sender;
 
-        while (hcpInHierarchy.getParentId() != null) {
+        while (hcpInHierarchy.getParentId() != null && hcpInHierarchy.getParentId() != "") {
             hcpInHierarchy = this.getHealthcareParty(hcpInHierarchy.getParentId());
             hcpartyIds.add(hcpInHierarchy.getId());
         }


### PR DESCRIPTION
When a Sumehr is generated, the HCP hierarchy is resolved. 

This hierarchy is built by running through the full HCP parent genealogy.

It happens that HCP have no parent. If so, the case where hcp.getParentId() == null is handle. But it also happens that hcp.getParentId() == "". 

The purpose of this PR is to handle the later case and therefore to handle missing HCP Id queries throwing :

 protected void assertDocIdHasValue(String docId) {
        Assert.hasText(docId, "document id cannot be empty");
 }

<img width="1376" alt="Screen Shot 2020-03-20 at 11 03 25" src="https://user-images.githubusercontent.com/7938129/77156577-e3a7f100-6a9f-11ea-8f12-df87720c91ff.png">
